### PR TITLE
Replaced ReadLine with Ctrl+C check to shutdown

### DIFF
--- a/SteamWebPipes/Bootstrap.cs
+++ b/SteamWebPipes/Bootstrap.cs
@@ -75,20 +75,20 @@ namespace SteamWebPipes
             timer.Interval = TimeSpan.FromSeconds(30).TotalMilliseconds;
             timer.Start();
 
-            Console.ReadLine();
+            Console.CancelKeyPress += delegate {
+                Console.WriteLine("Ctrl + C detected, shutting down.");
+                File.WriteAllText("last-changenumber.txt", steam.PreviousChangeNumber.ToString());
 
-            File.WriteAllText("last-changenumber.txt", steam.PreviousChangeNumber.ToString());
+                steam.IsRunning = false;
+                thread.Abort();
+                timer.Stop();
 
-            steam.IsRunning = false;
-            thread.Abort();
-            timer.Stop();
+                foreach (var socket in ConnectedClients.ToList()) {
+                    socket.Close();
+                }
 
-            foreach (var socket in ConnectedClients.ToList())
-            {
-                socket.Close();
-            }
-
-            server.Dispose();
+                server.Dispose();
+            };
         }
 
         private static void TimerTick(object sender, ElapsedEventArgs e)


### PR DESCRIPTION
Replaced the "ReadLine()" wait with a while true loop and Ctrl+C check to shutdown.

Much cleaner and standardised way to shut down a program, prevents accidental shutdowns, and allows for Ubuntu's Upstart to start it as a service.
